### PR TITLE
Add golang blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ These blueprints are meant to show typical actions you might want to perform in 
 
 All of the examples take 3 command line arguements:
 
-* *port* - port for the webhook server to listen on (default 80)
-* *server-url* - public HTTPS url of your MicroMDM server
-* *api-key* - API Key for your MicroMDM server
+* **port** - port for the webhook server to listen on (default 80)
+* **server-url** - public HTTPS url of your MicroMDM server
+* **api-key** - API Key for your MicroMDM server
 
 ## Go
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,22 @@
 # MicroMDM Webhook Blueprints
-Example webhook listeners for the MicroMDM server in different languages
+Example webhook listeners for the MicroMDM server in different languages.
+
+These blueprints are meant to show typical actions you might want to perform in response to the webhook functionality of the MicroMDM server. The webhook listener will watch for new devices and when one enrolls or re-enrolls it will ask the device for a list of installed applications.
+
+All of the examples take 3 command line arguements:
+
+* *port* - port for the webhook server to listen on (default 80)
+* *server-url* - public HTTPS url of your MicroMDM server
+* *api-key* - API Key for your MicroMDM server
 
 ## Go
+
+```
+cd go
+go build -o micromdm-webhook
+./micromdm-webhook -server-url https://my-server-url -api-key MySecretAPIKey 
+```
 
 ## Python
 
 ## NodeJS
-
-## Swift

--- a/go/micromdm-webhook.go
+++ b/go/micromdm-webhook.go
@@ -1,25 +1,140 @@
 package main
 
 import (
-	"fmt"
-	"io"
+	"bytes"
+	"encoding/json"
+	"flag"
 	"log"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
+
+	"github.com/micromdm/micromdm/workflow/webhook"
 )
 
-func handleWebhook(w http.ResponseWriter, r *http.Request) {
-	fmt.Printf("headers: %v\n", r.Header)
+type Device struct {
+	UDID     string
+	Enrolled bool
+}
 
-	_, err := io.Copy(os.Stdout, r.Body)
+type Server struct {
+	MDMServerURL string
+	MDMAPIKey    string
+	Devices      map[string]Device
+}
+
+type Command struct {
+	UDID        string `json:"udid"`
+	RequestType string `json:"request_type"`
+}
+
+func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	var event webhook.Event
+	err := json.NewDecoder(r.Body).Decode(&event)
 	if err != nil {
-		log.Println(err)
+		log.Fatal(err)
 		return
+	}
+
+	switch event.Topic {
+	case "mdm.Authenticate":
+		s.handleAuthenticate(event)
+	case "mdm.TokenUpdate":
+		s.handleTokenUpdate(event)
+	case "mdm.Connect":
+		s.handleConnect(event)
+	case "mdm.CheckOut":
+		s.handleCheckOut(event)
+	}
+}
+
+// Authenticate messages are sent when the device is installing a MDM payload.
+func (s *Server) handleAuthenticate(event webhook.Event) {
+	d, exists := s.Devices[event.CheckinEvent.UDID]
+	d.UDID = event.CheckinEvent.UDID
+	d.Enrolled = false
+	s.Devices[event.CheckinEvent.UDID] = d
+
+	if exists {
+		log.Println("re-enrolling device", d.UDID)
+	} else {
+		log.Println("enrolling new device", d.UDID)
+	}
+}
+
+// A device sends a token update message to the MDM server whenever its device
+// push token, push magic, or unlock token change. The device sends an initial
+// token update message to the server when it has installed the MDM payload.
+// The server should send push messages to the device only after receiving the
+// first token update message.
+func (s *Server) handleTokenUpdate(event webhook.Event) {
+	d := s.Devices[event.CheckinEvent.UDID]
+	d.UDID = event.CheckinEvent.UDID
+	d.Enrolled = true
+	s.Devices[event.CheckinEvent.UDID] = d
+
+	s.sendCommandToDevice(d, "InstalledApplicationList")
+}
+
+// Connect events occur when a device is responding to a MDM command. They
+// contain the raw responses from the device.
+//
+// https://developer.apple.com/enterprise/documentation/MDM-Protocol-Reference.pdf
+func (s *Server) handleConnect(event webhook.Event) {
+	xml := string(event.AcknowledgeEvent.RawPayload)
+	if strings.Contains(xml, "InstalledApplicationList") {
+		log.Println(xml)
+	}
+}
+
+// In iOS 5.0 and later, and in macOS v10.9, if the CheckOutWhenRemoved key in
+// the MDM payload is set to true, the device attempts to send a CheckOut
+// message when the MDM profile is removed.
+func (s *Server) handleCheckOut(event webhook.Event) {
+	d := s.Devices[event.CheckinEvent.UDID]
+	d.UDID = event.CheckinEvent.UDID
+	d.Enrolled = false
+	s.Devices[event.CheckinEvent.UDID] = d
+}
+
+func (s *Server) sendCommandToDevice(d Device, requestType string) {
+	c := Command{
+		UDID:        d.UDID,
+		RequestType: requestType,
+	}
+	b := new(bytes.Buffer)
+	json.NewEncoder(b).Encode(c)
+
+	client := &http.Client{}
+	req, err := http.NewRequest("POST", s.MDMServerURL+"/v1/commands", b)
+	req.SetBasicAuth("micromdm", s.MDMAPIKey)
+	_, err = client.Do(req)
+	if err != nil {
+		log.Fatal(err)
 	}
 }
 
 func main() {
-	log.Println("server started")
-	http.HandleFunc("/webhook", handleWebhook)
-	log.Fatal(http.ListenAndServe(":8081", nil))
+	var (
+		flPort      = flag.Int("port", 80, "port for the webhook server to listen on")
+		flServerURL = flag.String("server-url", "", "public HTTPS url of your MicroMDM server")
+		flAPIKey    = flag.String("api-key", "", "API Key for your MicroMDM server")
+	)
+	flag.Parse()
+
+	if *flServerURL == "" || *flAPIKey == "" {
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	s := &Server{
+		MDMServerURL: strings.TrimRight(*flServerURL, "/"),
+		MDMAPIKey:    *flAPIKey,
+		Devices:      make(map[string]Device),
+	}
+
+	log.Println("webhook server listening on port", *flPort)
+	http.HandleFunc("/webhook", s.handleWebhook)
+	log.Fatal(http.ListenAndServe(":"+strconv.Itoa(*flPort), nil))
 }


### PR DESCRIPTION
This creates a MicroMDM webhook example in Go. All other languages will follow this pattern. The webhook listens for newly enrolled devices and requests a list of installed applications.